### PR TITLE
computing a gir_path relative to RbConfig datadir

### DIFF
--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -1,11 +1,12 @@
 require "yard"
 require "rexml/document"
+require "rbconfig"
 
 class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
   handles :module
 
   def process
-    gir_path = "/usr/share/gir-1.0"
+    gir_path = File.expand_path("gir-1.0", RbConfig::CONFIG["datadir"])
 
     @module_name = statement[0].source
     girs_files = Dir.glob("#{gir_path}/#{@module_name}-?.*gir")


### PR DESCRIPTION
In the `process` instance method for `GObjectIntropsectionHandler` of [yard-gobject-introspection](https://github.com/ruby-gnome/yard-gobject-introspection), the `gir_path` value was initialized as relative to `/usr/share`

This patch sets the `gir_path` initial value as relative to the value of `RbConfig::CONFIG['datadir']`.  

This pathname may be portable for systems that would use a prefix installation path other than `/usr` for the gir metadata, e.g  a prefix path `/usr/local` for FreeBSD ports or `/usr/pkg` for pkgsrc

(Tested with Vte documentation using Ruby 3.1 on FreeBSD 13.1)

(cherry picked from commit https://github.com/rubyblox/yard-gobject-introspection/commit/24e7e1ebd541232c478a95aa3da572d162ea813c in contrib)