### PR TITLE
Improvements for documenting Arrow

### DIFF
--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -307,7 +307,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     end
     ret_infos = read_return_value_information(function.elements["return-value"])
     documentation += "\n@return [#{ret_infos[:type]}] #{ret_infos[:doc]}"
-    name = function.attributes["name"]
+    name = method_type == 'constructor' ? 'initialize' : function.attributes["name"]
     name = rubyish_method_name(name, parameters.size, ret_infos[:type])
     method = MethodObject.new(container, name, method_type == 'function' ? :class : :instance)
     method.parameters = parameters

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -163,6 +163,10 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     klass_name = klass.attributes["name"]
     klass_yo = ClassObject.new(parent, klass_name)
     @klasses_yo[klass_name] = klass_yo
+    parent_klass = klass.attributes["parent"]
+    if !parent_klass.nil? && parent_klass != "GObject.Object"
+      klass_yo.superclass = parent_klass.gsub("\.", "::")
+    end
     klass_yo.docstring = read_doc(klass)
     register_constructors(klass, klass_yo)
     register_methods(klass, klass_yo)

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -168,6 +168,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
       klass_yo.superclass = parent_klass.gsub("\.", "::")
     end
     klass_yo.docstring = read_doc(klass)
+    register_functions(klass, klass_yo)
     register_constructors(klass, klass_yo)
     register_methods(klass, klass_yo)
     register_properties(klass, klass_yo)
@@ -178,6 +179,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     klass_yo = ClassObject.new(parent, klass_name)
     @klasses_yo[klass_name] = klass_yo
     klass_yo.docstring = read_doc(klass)
+    register_functions(klass, klass_yo)
     register_constructors(klass, klass_yo)
     register_methods(klass, klass_yo)
     register_properties(klass, klass_yo)
@@ -270,6 +272,10 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     _register_methods(klass, klass_yo, "method")
   end
 
+  def register_functions(klass, klass_yo)
+    _register_methods(klass, klass_yo, "function")
+  end
+
   def register_constructors(klass, klass_yo)
     _register_methods(klass, klass_yo, "constructor")
   end
@@ -303,7 +309,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     documentation += "\n@return [#{ret_infos[:type]}] #{ret_infos[:doc]}"
     name = function.attributes["name"]
     name = rubyish_method_name(name, parameters.size, ret_infos[:type])
-    method = MethodObject.new(container, name)
+    method = MethodObject.new(container, name, method_type == 'function' ? :class : :instance)
     method.parameters = parameters
     method.docstring = documentation
     rescue => error

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -334,6 +334,10 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     type = nil
     if node.elements["type"]
       type = ctypes_to_ruby(node.elements["type"].attributes["name"])
+      if node.elements["type"].elements["type"]
+        subtype = ctypes_to_ruby(node.elements["type"].elements["type"].attributes["name"])
+        type = "#{type}<#{subtype}>"
+      end
     elsif node.elements["array"]
       type = node.elements["array/type"].attributes["name"]
       type = "Array<#{ctypes_to_ruby(type)}>"
@@ -351,6 +355,10 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     type = nil
     if node.elements["type"]
       type = ctypes_to_ruby(node.elements["type"].attributes["name"])
+      if node.elements["type"].elements["type"]
+        subtype = ctypes_to_ruby(node.elements["type"].elements["type"].attributes["name"])
+        type = "#{type}<#{subtype}>"
+      end
     elsif node.elements["array"]
       type = node.elements["array/type"].attributes["name"]
       type = "Array<#{ctypes_to_ruby(type)}>"

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -10,7 +10,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
   def process
     return if @@has_processed_module
 
-    gir_path = File.expand_path("gir-1.0", RbConfig::CONFIG["datadir"])
+    gir_path = ENV['GIR_PATH'] || File.expand_path("gir-1.0", RbConfig::CONFIG["datadir"])
 
     @module_name = statement[0].source
     girs_files = Dir.glob("#{gir_path}/#{@module_name}-?.*gir")

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -307,7 +307,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     end
     ret_infos = read_return_value_information(function.elements["return-value"])
     documentation += "\n@return [#{ret_infos[:type]}] #{ret_infos[:doc]}"
-    name = method_type == 'constructor' ? 'initialize' : function.attributes["name"]
+    name = method_type == "constructor" ? "initialize" : function.attributes["name"]
     name = rubyish_method_name(name, parameters.size, ret_infos[:type])
     method = MethodObject.new(container, name, method_type == 'function' ? :class : :instance)
     method.parameters = parameters

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -241,7 +241,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
 
       if readable == "1"
         rname = method_name
-        rname += "?" if type == "TrueClass"
+        rname += "?" if type == "Boolean"
         documentation += "\n@return [#{type}] #{name}"
         method = MethodObject.new(klass_yo, rname)
         method.docstring = documentation
@@ -370,7 +370,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     when /(utf8)|(gunichar)/
       "String"
     when "gboolean"
-      "TrueClass"
+      "Boolean"
     when "none"
       "nil"
     when "gpointer"

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -165,7 +165,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
     @klasses_yo[klass_name] = klass_yo
     parent_klass = klass.attributes["parent"]
     if !parent_klass.nil? && parent_klass != "GObject.Object"
-      klass_yo.superclass = parent_klass.gsub("\.", "::")
+      klass_yo.superclass = parent_klass.gsub(".", "::")
     end
     klass_yo.docstring = read_doc(klass)
     register_functions(klass, klass_yo)

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -8,7 +8,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
   @@processed_modules = []
 
   def process
-    gir_path = ENV['GIR_PATH'] || File.expand_path("gir-1.0", RbConfig::CONFIG["datadir"])
+    gir_path = ENV["GI_GIR_PATH"] || File.expand_path("gir-1.0", RbConfig::CONFIG["datadir"])
 
     @module_name = statement[0].source
     return if @@processed_modules.include?(@module_name)

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -5,7 +5,11 @@ require "rbconfig"
 class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
   handles :module
 
+  @@has_processed_module = false
+
   def process
+    return if @@has_processed_module
+
     gir_path = File.expand_path("gir-1.0", RbConfig::CONFIG["datadir"])
 
     @module_name = statement[0].source
@@ -42,6 +46,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
       end
     end
 
+    @@has_processed_module = true
 #    parse_orphan_class_element
   end
 

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -5,14 +5,14 @@ require "rbconfig"
 class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
   handles :module
 
-  @@has_processed_module = false
+  @@processed_modules = []
 
   def process
-    return if @@has_processed_module
-
     gir_path = ENV['GIR_PATH'] || File.expand_path("gir-1.0", RbConfig::CONFIG["datadir"])
 
     @module_name = statement[0].source
+    return if @@processed_modules.include?(@module_name)
+
     girs_files = Dir.glob("#{gir_path}/#{@module_name}-?.*gir")
     gir_file = girs_files.last
     file = File.new(gir_file)
@@ -46,7 +46,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
       end
     end
 
-    @@has_processed_module = true
+    @@processed_modules << @module_name
 #    parse_orphan_class_element
   end
 

--- a/lib/yard-gobject-introspection.rb
+++ b/lib/yard-gobject-introspection.rb
@@ -336,7 +336,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
       type = ctypes_to_ruby(node.elements["type"].attributes["name"])
       if node.elements["type"].elements["type"]
         subtype = ctypes_to_ruby(node.elements["type"].elements["type"].attributes["name"])
-        type = "#{type}<#{subtype}>"
+        type << "<#{subtype}>"
       end
     elsif node.elements["array"]
       type = node.elements["array/type"].attributes["name"]
@@ -357,7 +357,7 @@ class GObjectIntropsectionHandler < YARD::Handlers::Ruby::Base
       type = ctypes_to_ruby(node.elements["type"].attributes["name"])
       if node.elements["type"].elements["type"]
         subtype = ctypes_to_ruby(node.elements["type"].elements["type"].attributes["name"])
-        type = "#{type}<#{subtype}>"
+        type << "<#{subtype}>"
       end
     elsif node.elements["array"]
       type = node.elements["array/type"].attributes["name"]


### PR DESCRIPTION
Currently there is no good documentation for the Arrow Ruby bindings. You need to look at both the Ruby code and the C GLib bindings to try to piece together which classes and methods are available.

Check out `arrow` and `yard-gobject-introspection` side by side, and run the following command inside the `arrow/ruby/red-arrow` directory:

```
$ GI_GIR_PATH=/opt/homebrew/share/gir-1.0 yard doc --load ../../../yard-gobject-introspection/lib/yard-gobject-introspection.rb --verbose --debug
```

This generates documentation in the `doc` directory that should contain all the classes and methods from both the C GLib bindings and the Ruby code together.

In addition to the `GI_GIR_PATH` environment variable, this adds information about superclasses, class methods, and subtypes to the generated documentation. It is still not perfect, but I find it very useful.

It also makes sure to only process each GIR-file once.